### PR TITLE
RFLS-537: Location Input - Attempt to pick the first geosuggestion on…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 npm-debug.log
+.idea/

--- a/lib/components/search/location/CRUKSearchkitLocationInput.js
+++ b/lib/components/search/location/CRUKSearchkitLocationInput.js
@@ -125,6 +125,29 @@ var CRUKSearchkitLocationInput = function (_SearchkitComponent) {
       var exitingItem = document.getElementsByClassName('geosuggest-item--disabled');
       if (exitingItem[0]) this.refs.geoSuggest.setState({ userInput: '' });
       this.removeEmptyLabel();
+
+      // Add the first suggest as default on field blur.
+      var suggests = this.refs.geoSuggest.state.suggests;
+
+      if (suggests && suggests[0] && !this.refs.geoSuggest.state.activeSuggest) {
+        this.reverseGeocode(suggests[0]);
+      }
+    }
+  }, {
+    key: 'reverseGeocode',
+    value: function reverseGeocode(suggest) {
+      var self = this;
+      this.refs.geoSuggest.geocoder.geocode({ placeId: suggest.placeId }, function (results, status) {
+        if (status === window.google.maps.GeocoderStatus.OK && results[0].geometry && self.props.updateSearch) {
+          var loc = {
+            placeId: suggest.placeId,
+            lat: results[0].geometry.location.lat(),
+            lng: results[0].geometry.location.lng()
+          };
+
+          self.props.updateSearch.call(self, { loc: loc });
+        }
+      });
     }
   }, {
     key: 'getSuggestLabel',
@@ -293,7 +316,8 @@ var CRUKSearchkitLocationInput = function (_SearchkitComponent) {
             location: this.props.location,
             radius: this.props.radius,
             country: this.props.country,
-            inputClassName: inputClassName
+            inputClassName: inputClassName,
+            autoActivateFirstSuggest: this.props.autoActivateFirstSuggest
           }),
           _react2.default.createElement('div', { className: 'geoSuggestLoader', ref: 'geoLoader' })
         )
@@ -310,6 +334,8 @@ CRUKSearchkitLocationInput.propTypes = _extends({
   initialValue: _react2.default.PropTypes.string,
   radius: _react2.default.PropTypes.string,
   location: _react2.default.PropTypes.object,
-  fixtures: _react2.default.PropTypes.array
+  fixtures: _react2.default.PropTypes.array,
+  autoActivateFirstSuggest: _react2.default.PropTypes.bool,
+  updateSearch: _react2.default.PropTypes.func
 }, _searchkit.SearchkitComponent.propTypes);
 exports.default = CRUKSearchkitLocationInput;


### PR DESCRIPTION
… blur/enter.

1) Added autoActivateFirstSuggest to the Geosuggest component, if the component is also on the CRUKLocationInput itself.

2) Made changes to onblur to mirror onblur in CRUKRFLSearch widget [LocationInput.jsx](https://github.com/CRUKorg/CRUKRFLSearch/blob/develop/src/components/rfl_widget/Location.jsx)