### PR TITLE
Fix for search term in GA tracking

### DIFF
--- a/lib/components/search/gtm/CRUKSearchkitGTM.js
+++ b/lib/components/search/gtm/CRUKSearchkitGTM.js
@@ -100,11 +100,15 @@ var CRUKSearchkitGTM = function (_SearchkitComponent) {
   }, {
     key: 'trackResultsChange',
     value: function trackResultsChange(results) {
+      var _this3 = this;
+
       /**
        * Construct the payload.
        */
       var gtmSearchTitle = this.props.searchName || 'Unnamed React search';
-      var query = this.searchkit.state.q;
+      var query = Object.keys(this.searchkit.state).map(function (k, i) {
+        return _this3.searchkit.state[k];
+      }).join(', ');
       var page = typeof this.searchkit.state.p == 'undefined' ? 1 : this.searchkit.state.p;
       var totalResults = this.getHitsCount();
 

--- a/lib/components/search/gtm/CRUKSearchkitGTM.js
+++ b/lib/components/search/gtm/CRUKSearchkitGTM.js
@@ -100,15 +100,12 @@ var CRUKSearchkitGTM = function (_SearchkitComponent) {
   }, {
     key: 'trackResultsChange',
     value: function trackResultsChange(results) {
-      var _this3 = this;
-
       /**
        * Construct the payload.
        */
       var gtmSearchTitle = this.props.searchName || 'Unnamed React search';
-      var query = Object.keys(this.searchkit.state).map(function (k, i) {
-        return _this3.searchkit.state[k];
-      }).join(', ');
+      var keywordField = this.props.keywordField || 'q';
+      var query = this.searchkit.state[keywordField];
       var page = typeof this.searchkit.state.p == 'undefined' ? 1 : this.searchkit.state.p;
       var totalResults = this.getHitsCount();
 
@@ -187,7 +184,8 @@ CRUKSearchkitGTM.propTypes = {
   dataLayerName: _react2.default.PropTypes.string,
   additionalEvents: _react2.default.PropTypes.object,
   scriptId: _react2.default.PropTypes.string,
-  searchName: _react2.default.PropTypes.string
+  searchName: _react2.default.PropTypes.string,
+  keywordField: _react2.default.PropTypes.string
 };
 
 exports.default = CRUKSearchkitGTM;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cruk-searchkit",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Set of overriden and new searchkit components designed specifically for Cancer Research UK",
   "main": "index.js",
   "scripts": {

--- a/src/components/search/gtm/CRUKSearchkitGTM.jsx
+++ b/src/components/search/gtm/CRUKSearchkitGTM.jsx
@@ -65,7 +65,9 @@ class CRUKSearchkitGTM extends SearchkitComponent {
      * Construct the payload.
      */
     const gtmSearchTitle = this.props.searchName || 'Unnamed React search';
-    let query = this.searchkit.state.q;
+    let query = Object.keys(this.searchkit.state).map((k, i) => {
+      return this.searchkit.state[k];
+    }).join(', ');
     let page = typeof this.searchkit.state.p == 'undefined' ? 1 : this.searchkit.state.p;
     let totalResults = this.getHitsCount();
 

--- a/src/components/search/gtm/CRUKSearchkitGTM.jsx
+++ b/src/components/search/gtm/CRUKSearchkitGTM.jsx
@@ -65,9 +65,8 @@ class CRUKSearchkitGTM extends SearchkitComponent {
      * Construct the payload.
      */
     const gtmSearchTitle = this.props.searchName || 'Unnamed React search';
-    let query = Object.keys(this.searchkit.state).map((k, i) => {
-      return this.searchkit.state[k];
-    }).join(', ');
+    const keywordField =  this.props.keywordField || 'q';
+    const query = this.searchkit.state[keywordField];
     let page = typeof this.searchkit.state.p == 'undefined' ? 1 : this.searchkit.state.p;
     let totalResults = this.getHitsCount();
 
@@ -136,7 +135,8 @@ CRUKSearchkitGTM.propTypes = {
   dataLayerName: React.PropTypes.string,
   additionalEvents: React.PropTypes.object,
   scriptId: React.PropTypes.string,
-  searchName: React.PropTypes.string
+  searchName: React.PropTypes.string,
+  keywordField: React.PropTypes.string
 };
 
 export default CRUKSearchkitGTM;


### PR DESCRIPTION
The CRUKSearchkit state.q was not working because the id for search box has been renamed in CRUKXSS, therefore it was undefined. In order to solve this, we have added a property to CRUKSearchGtm called KeywordField which can be use to pass in value from search field when search field id is renamed to something else then q. By default, the q will be the identifier for the search state object. 