### PR TITLE
DIG-1294: Date - Use both start & end date fields to determine date range query modifier.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea
 node_modules
 npm-debug.log

--- a/lib/components/search/date/CRUKSearchkitDateRange.js
+++ b/lib/components/search/date/CRUKSearchkitDateRange.js
@@ -120,11 +120,13 @@ var CRUKSearchkitDateRange = function (_SearchkitComponent) {
           startDate = _props.startDate,
           endDate = _props.endDate,
           interval = _props.interval,
-          showHistogram = _props.showHistogram;
+          showHistogram = _props.showHistogram,
+          startDateField = _props.startDateField,
+          endDateField = _props.endDateField;
 
       var updateParentState = this.updateParentState;
       return new _CRUKSearchkitDateRangeAccessor.CRUKSearchkitDateRangeAccessor(id, {
-        id: id, startDate: startDate, endDate: endDate, title: title, field: field, interval: interval, updateParentState: updateParentState
+        id: id, startDate: startDate, endDate: endDate, title: title, field: field, interval: interval, updateParentState: updateParentState, startDateField: startDateField, endDateField: endDateField
       });
     }
   }, {
@@ -185,6 +187,8 @@ CRUKSearchkitDateRange.propTypes = _extends({
   displayFormat: _react2.default.PropTypes.string,
   showClearDates: _react2.default.PropTypes.bool,
   field: _react2.default.PropTypes.string,
+  startDateField: _react2.default.PropTypes.string,
+  endDateField: _react2.default.PropTypes.string,
   id: _react2.default.PropTypes.string
 }, _searchkit.SearchkitComponent.propTypes);
 

--- a/lib/components/search/date/CRUKSearchkitDateRangeAccessor.js
+++ b/lib/components/search/date/CRUKSearchkitDateRangeAccessor.js
@@ -50,11 +50,54 @@ var CRUKSearchkitDateRangeAccessor = exports.CRUKSearchkitDateRangeAccessor = fu
       if (this.state.hasValue()) {
         var val = this.state.getValue();
         this.options.updateParentState(val.min, val.max);
+
+        // Default to using `field` prop.
         var rangeFilter = (0, _searchkit.RangeQuery)(this.options.field, {
           gte: val.min,
           lt: this.addOneDay(val.max),
           format: 'yyyy-MM-dd'
         });
+
+        if (this.options.startDateField && this.options.endDateField) {
+          // If both `startDateField` & `endDateField` have been defined, use these to set
+          // upper & lower bounds on date range, ignore `field` prop.
+          rangeFilter = (0, _searchkit.BoolShould)([
+          // Find all events for which one of these criteria is true:
+          // 1) The event start date is after the input start date but before/on the input end date.
+
+          (0, _searchkit.RangeQuery)(this.options.startDateField, {
+            gte: val.min,
+            lte: this.addOneDay(val.max),
+            format: 'yyyy-MM-dd'
+          }),
+          // OR
+          // 2) The event end date is before the input end date but after the input start date.
+          (0, _searchkit.RangeQuery)(this.options.endDateField, {
+            gte: val.min,
+            lte: this.addOneDay(val.max),
+            format: 'yyyy-MM-dd'
+          }),
+          // OR
+          // 3) The event start date is before the input start date and the event end date is after the input end date.
+          (0, _searchkit.BoolMust)([(0, _searchkit.RangeQuery)(this.options.startDateField, {
+            lt: val.min,
+            format: 'yyyy-MM-dd'
+          }), (0, _searchkit.RangeQuery)(this.options.endDateField, {
+            gt: this.addOneDay(val.max),
+            format: 'yyyy-MM-dd'
+          })]),
+          // OR
+          // 4) The event has no start or end date.
+          (0, _searchkit.BoolMustNot)([{
+            exists: {
+              field: this.options.startDateField
+            }
+          }, {
+            exists: {
+              field: this.options.endDateField
+            }
+          }])]);
+        }
 
         var selectedFilter = {
           name: this.translate(this.options.title),
@@ -82,15 +125,20 @@ var CRUKSearchkitDateRangeAccessor = exports.CRUKSearchkitDateRangeAccessor = fu
       var val = this.state.getValue();
       var min = val.min;
       var max = val.max;
+      var field = this.options.field;
+
+      if (this.options.startDateField && this.options.endDateField) {
+        field = this.options.startDateField;
+      }
 
       var otherFilters = query.getFiltersWithoutKeys(this.key);
-      var filters = (0, _searchkit.BoolMust)([otherFilters, (0, _searchkit.RangeQuery)(this.options.field, {
+      var filters = (0, _searchkit.BoolMust)([otherFilters, (0, _searchkit.RangeQuery)(field, {
         gte: min,
         lt: this.addOneDay(val.max),
         format: 'yyyy-MM-dd'
       })]);
 
-      var metric = (0, _searchkit.CardinalityMetric)(this.key, this.options.field);
+      var metric = (0, _searchkit.CardinalityMetric)(this.key, field);
 
       return query.setAggs((0, _searchkit.FilterBucket)(this.key, filters, metric));
     }

--- a/src/components/search/date/CRUKSearchkitDateRange.jsx
+++ b/src/components/search/date/CRUKSearchkitDateRange.jsx
@@ -29,6 +29,8 @@ class CRUKSearchkitDateRange extends SearchkitComponent {
     displayFormat: React.PropTypes.string,
     showClearDates: React.PropTypes.bool,
     field: React.PropTypes.string,
+    startDateField: React.PropTypes.string,
+    endDateField: React.PropTypes.string,
     id: React.PropTypes.string,
     ...SearchkitComponent.propTypes
   }
@@ -88,10 +90,10 @@ class CRUKSearchkitDateRange extends SearchkitComponent {
 
   defineAccessor() {
     const { id, title, field, startDate, endDate,
-      interval, showHistogram } = this.props
-    const updateParentState = this.updateParentState
+      interval, showHistogram, startDateField, endDateField } = this.props;
+    const updateParentState = this.updateParentState;
     return new CRUKSearchkitDateRangeAccessor(id,{
-      id, startDate, endDate, title, field, interval, updateParentState
+      id, startDate, endDate, title, field, interval, updateParentState, startDateField, endDateField
     })
   }
 

--- a/src/components/search/date/CRUKSearchkitDateRangeAccessor.jsx
+++ b/src/components/search/date/CRUKSearchkitDateRangeAccessor.jsx
@@ -2,7 +2,9 @@ import {
   FilterBasedAccessor,
   ObjectState,
   RangeQuery,
+  BoolShould,
   BoolMust,
+  BoolMustNot,
   CardinalityMetric,
   FilterBucket
 } from 'searchkit';
@@ -25,11 +27,62 @@ export class CRUKSearchkitDateRangeAccessor extends FilterBasedAccessor {
     if (this.state.hasValue()) {
       let val = this.state.getValue();
       this.options.updateParentState(val.min, val.max);
+
+      // Default to using `field` prop.
       let rangeFilter = RangeQuery(this.options.field, {
         gte: val.min,
         lt: this.addOneDay(val.max),
         format: 'yyyy-MM-dd'
       });
+
+      if (this.options.startDateField && this.options.endDateField) {
+        // If both `startDateField` & `endDateField` have been defined, use these to set
+        // upper & lower bounds on date range, ignore `field` prop.
+        rangeFilter = BoolShould([
+          // Find all events for which one of these criteria is true:
+          // 1) The event start date is after the input start date but before/on the input end date.
+
+          RangeQuery(this.options.startDateField, {
+            gte: val.min,
+            lte: this.addOneDay(val.max),
+            format: 'yyyy-MM-dd'
+          }),
+          // OR
+          // 2) The event end date is before the input end date but after the input start date.
+          RangeQuery(this.options.endDateField, {
+            gte: val.min,
+            lte: this.addOneDay(val.max),
+            format: 'yyyy-MM-dd'
+          }),
+          // OR
+          // 3) The event start date is before the input start date and the event end date is after the input end date.
+          BoolMust([
+            RangeQuery(this.options.startDateField, {
+              lt: val.min,
+              format: 'yyyy-MM-dd'
+            }),
+            RangeQuery(this.options.endDateField, {
+              gt: this.addOneDay(val.max),
+              format: 'yyyy-MM-dd'
+            })
+          ]),
+          // OR
+          // 4) The event has no start or end date.
+          BoolMustNot([
+            {
+              exists: {
+                field: this.options.startDateField
+              }
+            },
+            {
+              exists: {
+                field: this.options.endDateField
+              }
+            }
+          ])
+        ])
+      }
+
 
       let selectedFilter = {
         name:this.translate(this.options.title),
@@ -59,18 +112,23 @@ export class CRUKSearchkitDateRangeAccessor extends FilterBasedAccessor {
     const val = this.state.getValue();
     const min = val.min;
     const max = val.max;
+    let field = this.options.field;
+
+    if (this.options.startDateField && this.options.endDateField) {
+      field = this.options.startDateField;
+    }
 
     let otherFilters = query.getFiltersWithoutKeys(this.key);
     let filters = BoolMust([
       otherFilters,
-      RangeQuery(this.options.field,{
-        gte:min,
+      RangeQuery(field, {
+        gte: min,
         lt: this.addOneDay(val.max),
         format: 'yyyy-MM-dd'
       })
     ]);
 
-    const metric = CardinalityMetric(this.key, this.options.field);
+    const metric = CardinalityMetric(this.key, field);
 
     return query.setAggs(FilterBucket(
       this.key,

--- a/src/components/search/date/tests/CRUKSearchkitDateRangeAccessor.unit.jsx
+++ b/src/components/search/date/tests/CRUKSearchkitDateRangeAccessor.unit.jsx
@@ -22,6 +22,16 @@ describe('CRUKSearchkitDateRangeAccessor tests', () => {
       updateParentState: () => null
     };
 
+    this.multipleDayOptions = {
+      id: 'date-filter',
+      startDateField: 'date_start',
+      endDateField: 'date_end',
+      title:'Date filter',
+      startDate: '2016-08-12',
+      endDate: '2016-08-15',
+      updateParentState: () => null
+    };
+
     this.accessor = new CRUKSearchkitDateRangeAccessor('date-filter', this.options);
 
   });
@@ -52,6 +62,76 @@ describe('CRUKSearchkitDateRangeAccessor tests', () => {
     });
   });
 
+  it('buildSharedQuery with specified start & end date', function() {
+    this.accessor = new CRUKSearchkitDateRangeAccessor('date-filter', this.multipleDayOptions);
+
+    let query = new ImmutableQuery();
+    query = this.accessor.buildSharedQuery(query);
+    let filters = query.getFilters();
+    expect(toPlainObject(filters)).toEqual({});
+
+    this.accessor.state = this.accessor.state.setValue({
+      min: '2016-08-12',
+      max: '2016-08-15'
+    });
+
+    query = new ImmutableQuery();
+    query = this.accessor.buildSharedQuery(query);
+    filters = query.getFilters();
+
+    expect(toPlainObject(filters)).toEqual({
+      bool: {
+        should: [{
+          range: {
+            date_start: {
+              gte: '2016-08-12',
+              lte: '2016-08-16',
+              format: 'yyyy-MM-dd'
+            }
+          }
+        }, {
+          range: {
+            date_end: {
+              gte: '2016-08-12',
+              lte: '2016-08-16',
+              format: 'yyyy-MM-dd'
+            }
+          }
+        }, {
+          bool: {
+            must: [{
+              range: {
+                date_start: {
+                  lt: '2016-08-12',
+                  format: 'yyyy-MM-dd'
+                }
+              }
+            }, {
+              range: {
+                date_end: {
+                  gt: '2016-08-16',
+                  format: 'yyyy-MM-dd'
+                }
+              }
+            }]
+          }
+        }, {
+          bool: {
+            must_not: [{
+              exists: {
+                field: 'date_start'
+              }
+            }, {
+              exists: {
+                field: 'date_end'
+              }
+            }]
+          }
+        }]
+      }
+    });
+  });
+
   it('buildOwnQuery', function() {
     let query = new ImmutableQuery();
     this.accessor.state = this.accessor.state.setValue({
@@ -69,6 +149,31 @@ describe('CRUKSearchkitDateRangeAccessor tests', () => {
       })
     ]);
     const metric = CardinalityMetric(this.accessor.key, this.accessor.options.field);
+
+    expect(toPlainObject(query.query.aggs)).toEqual(
+      FilterBucket(this.accessor.key, filters, metric)
+    );
+  });
+
+  it('buildOwnQuery with specified start & end date', function() {
+    this.accessor = new CRUKSearchkitDateRangeAccessor('date-filter', this.multipleDayOptions);
+
+    let query = new ImmutableQuery();
+    this.accessor.state = this.accessor.state.setValue({
+      min: '2016-08-12',
+      max: '2016-08-15'
+    });
+    query = this.accessor.buildOwnQuery(query);
+
+    // Comparison data.
+    const filters = BoolMust([
+      RangeQuery(this.accessor.options.startDateField, {
+        gte: '2016-08-12',
+        lt: this.accessor.addOneDay('2016-08-15'),
+        format: 'yyyy-MM-dd'
+      })
+    ]);
+    const metric = CardinalityMetric(this.accessor.key, this.accessor.options.startDateField);
 
     expect(toPlainObject(query.query.aggs)).toEqual(
       FilterBucket(this.accessor.key, filters, metric)

--- a/stories/story_components/CRUKSearchkitDateRange.jsx
+++ b/stories/story_components/CRUKSearchkitDateRange.jsx
@@ -11,6 +11,8 @@ module.exports = (searchkit) => {
   const story = (
     <CRUKSearchkitDateRange
       searchkit={searchkit}
+      startDateField="date_start"
+      endDateField="date_end"
       field="date_start"
       id="date"
       showClearDates


### PR DESCRIPTION
This PR is to improve the DateRange filter's support for multi-day events.

The current logic (i.e. without this PR) only searches based on the date specified by the `field` prop.  This works for documents which are concerned with things happening over the course of one day, but falls short when a document spans multiple days.

For example, if a document has a start date of 1st September and and end date of 7th September, a search using 3rd-5th September would fail to find the document since the document start date is earlier than the searched start date.

The logic proposed in this PR adds two new props to the DateRange component: `startDateField` and `endDateField`. These are designed to be alternatives to the `field` prop - both should be specified, or neither. The values of each of these fields should correspond to a date field in the queried index's schema.